### PR TITLE
Fix footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ conda install -c fastai fastdoc
 
 Suppose your notebook is in a folder called `book`. To run fastdoc:
 
-`fastdoc_convert_all --path book --dest_path convert_book` 
+`fastdoc_convert_all --path book --dest_path convert_book`
 
-You'll find your exported asciidoc files and all images used in `convert_book`. 
+You'll find your exported asciidoc files and all images used in `convert_book`.
 
-For a single notebook demonstrating all the features of `fastdoc`, see the `test/_test.ipynb` notebook. 
+**Note:** Filenames that start with an underscore `_` are ignored during the conversion.
+
+For a single notebook demonstrating all the features of `fastdoc`, see the `test/_test.ipynb` notebook.
 
 For a complete O'Reilly book written in this way, see [fastbook](https://github.com/fastai/fastbook/).

--- a/test/_test.asciidoc
+++ b/test/_test.asciidoc
@@ -107,7 +107,7 @@ inputs->program->results''')
 
 image::_test_files/output_8_0.svg["", 228]
 
-== Inputs and outputs
+=== Inputs and outputs
 
 By default inputs and outputs of each code cell are shown (except
 widgets).
@@ -188,7 +188,7 @@ input).
 
 To hide cell entirely, use the flag `#hide`.
 
-== Formatting
+=== Formatting
 
 `backward quotes`, 'single quotes' and "double
 quotes" are all left as is. Note that in asciidoc, text in single
@@ -263,8 +263,8 @@ This is a tip. Important gives the same rendering.
 ====
 
 
-For a traditional block quote, you still need to put a colon for
-correct rendering.
+For a traditional block quote, you still need to put a colon for correct
+rendering.
 
 ____
 The inside of block quotes is not converted so we need to use asciidoc syntax inside.
@@ -318,14 +318,18 @@ You can use math as usual in notebooks: latexmath:[\(x = \frac{a+b}{2}\)]
 
 Or
 
+
 [latexmath]
 ++++
-\[x = \frac{a+b}{2}\]
+\begin{equation}
+x = \frac{a+b}{2}
+\end{equation}
 ++++
 
-A footnote[this is a footnote]
 
-== Tables and images, caption and references
+A footnotefootnote:[this is a footnote]
+
+=== Tables and images, caption and references
 
 To add a caption and a reference to an output table, use `#id` and
 `#caption` flags

--- a/test/_test.ipynb
+++ b/test/_test.ipynb
@@ -573,7 +573,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A footnote[this is a footnote]"
+    "A footnotefootnote:[this is a footnote]"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the example to generate footnotes in `test/_test.ipynb`. Previously we had

```
A footnote[this is a footnote]
```

which generated via asciidoctor the following output:

![Screen Shot 2021-01-19 at 3 00 34 pm](https://user-images.githubusercontent.com/26859204/105048319-b6372580-5a6b-11eb-82d1-4f6830891eac.png)

With the fix, we now have:

![Screen Shot 2021-01-19 at 3 34 15 pm](https://user-images.githubusercontent.com/26859204/105048382-cc44e600-5a6b-11eb-95aa-0ebfd020f5a4.png)

which is consistent with the asciidoc [docs](https://asciidoc.org/chunked/ch18.html).

Closes #12 