### PR TITLE
Fix URLs in Asciidoc blocks

### DIFF
--- a/00_asciidoc.ipynb
+++ b/00_asciidoc.ipynb
@@ -735,6 +735,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Catch Markdown URLs of the form\n",
+    "\n",
+    "```\n",
+    "[link](https://github.com/fastai)\n",
+    "```\n",
+    "\n",
+    "inside asciidoc blocks. Asciidoc expects URLs to be in the following format:\n",
+    "\n",
+    "```\n",
+    "[BLOCK_NAME]\n",
+    "====\n",
+    "This is a block with some https://github.com/fastai[link]\n",
+    "====\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
+    "_re_urls = re.compile(\"\\[(.*?)\\]\\((.*?)\\)\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -746,6 +776,7 @@
     "                   'jargon':'JARGON', 'question':'QUESTION', 'a': 'ALEXIS', 'j': 'JEREMY', 's': 'SYLVAIN'}\n",
     "    def _rep(m):\n",
     "        typ,text = m.groups()\n",
+    "        text = re.sub(_re_urls, r\"\\2[\\1]\", text)\n",
     "        name = block_names.get(typ.lower(), typ.upper())\n",
     "        if name in ['ALEXIS', 'JEREMY', 'SYLVAIN', 'JARGON', 'QUESTION']:\n",
     "            title = name[0]+name[1:].lower()\n",
@@ -753,7 +784,7 @@
     "            if name=='JARGON':\n",
     "                splits = text.split(': ')\n",
     "                title = f'{title}: {splits[0]}'\n",
-    "                text = ': '.join(splits[1:])\n",
+    "                text = re.sub(_re_urls, r\"\\2[\\1]\", ': '.join(splits[1:]))\n",
     "            if name in ['ALEXIS', 'JEREMY', 'SYLVAIN']: \n",
     "                title = f\"{title} says\"\n",
     "                surro = 'TIP'\n",
@@ -773,8 +804,12 @@
    "source": [
     "test_eq(replace_jekylls(markdown_cell(\"text\\n> : This is a block quote\")),\n",
     "    markdown_cell(\"text\\n```asciidoc\\n____\\nThis is a block quote\\n____\\n```\\n\"))\n",
+    "test_eq(replace_jekylls(markdown_cell(\"text\\n> : This is a block quote with a [link](https://github.com/fastai)\")),\n",
+    "    markdown_cell(\"text\\n```asciidoc\\n____\\nThis is a block quote with a https://github.com/fastai[link]\\n____\\n```\\n\"))\n",
     "test_eq(replace_jekylls(markdown_cell(\"text\\n> jargon: term: Some new term\")),\n",
     "    markdown_cell('text\\n```asciidoc\\n.Jargon: term\\n[NOTE]\\n====\\nSome new term\\n====\\n```\\n'))\n",
+    "test_eq(replace_jekylls(markdown_cell(\"text\\n> jargon: term: Some new term with a [link](https://github.com/fastai)\")),\n",
+    "    markdown_cell('text\\n```asciidoc\\n.Jargon: term\\n[NOTE]\\n====\\nSome new term with a https://github.com/fastai[link]\\n====\\n```\\n'))\n",
     "test_warns(lambda: replace_jekylls(markdown_cell(\"text\\n> This is a block quote\")))"
    ]
   },
@@ -1687,5 +1722,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/fastdoc/asciidoc.py
+++ b/fastdoc/asciidoc.py
@@ -217,11 +217,15 @@ _re_block_notes = re.compile(r"""
 _re_forgot_column = re.compile("^\s*>[^:]*$", re.MULTILINE)
 
 # Cell
+_re_urls = re.compile("\[(.*?)\]\((.*?)\)")
+
+# Cell
 def replace_jekylls(cell):
     block_names = {'warning':'WARNING', 'note':'NOTE', 'important':'TIP', 'tip': 'TIP', 'stop': 'WARNING',
                    'jargon':'JARGON', 'question':'QUESTION', 'a': 'ALEXIS', 'j': 'JEREMY', 's': 'SYLVAIN'}
     def _rep(m):
         typ,text = m.groups()
+        text = re.sub(_re_urls, r"\2[\1]", text)
         name = block_names.get(typ.lower(), typ.upper())
         if name in ['ALEXIS', 'JEREMY', 'SYLVAIN', 'JARGON', 'QUESTION']:
             title = name[0]+name[1:].lower()
@@ -229,7 +233,7 @@ def replace_jekylls(cell):
             if name=='JARGON':
                 splits = text.split(': ')
                 title = f'{title}: {splits[0]}'
-                text = ': '.join(splits[1:])
+                text = re.sub(_re_urls, r"\2[\1]", ': '.join(splits[1:]))
             if name in ['ALEXIS', 'JEREMY', 'SYLVAIN']:
                 title = f"{title} says"
                 surro = 'TIP'


### PR DESCRIPTION
Hi @jph00, 

This PR squashes a bug I reported in #17 where Markdown URLs like `[link](https://github.com/fastai)` were not getting converted to the Asciidoc format inside NOTE, TIP, and WARNING blocks.

Closes #17 